### PR TITLE
Set proper caching options for .md5 files

### DIFF
--- a/templates/vhost_443.j2
+++ b/templates/vhost_443.j2
@@ -13,6 +13,14 @@
     Require all granted
   </Directory>
 
+  # Ensure we set proper headers for cache management.
+  <FileMatches "\.(md5)$">
+    FileEtag none
+    Header unset ETag
+    # Let cache for 1800s (30 minutes), but let's accept serving old data for another 30 minutes
+    Header set Cache-Control "max-age=1800, public, stale-if-error=1800"
+  </FileMatches>
+
 {% for worker in api_workers %}
   # WSGI configuration for worker {{ worker }}
   # NOTE(dpawlik): use python-path param instead of python-home,

--- a/templates/vhost_80.j2
+++ b/templates/vhost_80.j2
@@ -13,6 +13,14 @@
     Require all granted
   </Directory>
 
+  # Ensure we set proper headers for cache management.
+  <FileMatches "\.(md5)$">
+    FileEtag none
+    Header unset ETag
+    # Let cache for 1800s (30 minutes), but let's accept serving old data for another 30 minutes
+    Header set Cache-Control "max-age=1800, public, stale-if-error=1800"
+  </FileMatches>
+
 {% for worker in api_workers %}
   # WSGI configuration for worker {{ worker }}
   # NOTE(dpawlik): use python-path param instead of python-home,


### PR DESCRIPTION
This should avoid issues with cache desynchronization. The proposed
patch should ensure files are served from caching proxies for 30
minutes, then it should be refreshed.

In case the source (rdo server) is down, caching proxies should be able
to serve the file from cache for another 30 minutes. This is a nice
behavior in case of service unavailability due to maintenance, crash or
network outage.

More information about the Cache-Control options can be found here:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching
- https://www.askapache.com/htaccess/apache-speed-cache-control/

Note: this patch requires mod_headers to be loaded. It should be the
case by default on CentOS when we install httpd.